### PR TITLE
Update MusicGenreSection formatting and title size

### DIFF
--- a/src/components/music/MusicGenreSection.tsx
+++ b/src/components/music/MusicGenreSection.tsx
@@ -14,10 +14,16 @@ interface MusicGenreSectionProps {
   className?: string;
 }
 
-export function MusicGenreSection({ title, tracks, className }: MusicGenreSectionProps) {
+export function MusicGenreSection({
+  title,
+  tracks,
+  className,
+}: MusicGenreSectionProps) {
   return (
     <section className={className}>
-      <h2 className="text-2xl font-bold mb-4 font-[family-name:var(--font-permanent-marker)]">{title}</h2>
+      <h2 className="text-[33px] font-bold mb-4 font-[family-name:var(--font-permanent-marker)]">
+        {title}
+      </h2>
       <Carousel
         opts={{
           align: "start",
@@ -27,7 +33,10 @@ export function MusicGenreSection({ title, tracks, className }: MusicGenreSectio
       >
         <CarouselContent className="-ml-4">
           {tracks.map((track) => (
-            <CarouselItem key={track.id} className="pl-4 md:basis-1/2 lg:basis-1/3 xl:basis-1/4">
+            <CarouselItem
+              key={track.id}
+              className="pl-4 md:basis-1/2 lg:basis-1/3 xl:basis-1/4"
+            >
               <TrackCard track={track} />
             </CarouselItem>
           ))}


### PR DESCRIPTION
Updates formatting and styling in MusicGenreSection component:

- Reformats function parameters to multi-line format for better readability
- Changes h2 title font size from text-2xl to text-[33px]
- Splits h2 element across multiple lines for improved code formatting
- Reformats CarouselItem props to multi-line format
- Adds missing newline at end of file

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e1bc47cbc6464269a68d39b4d2ff956b/aura-world)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e1bc47cbc6464269a68d39b4d2ff956b</projectId>-->
<!--<branchName>aura-world</branchName>-->